### PR TITLE
Fix inline svg element with small size

### DIFF
--- a/packages/convert-svg-core/src/Converter.js
+++ b/packages/convert-svg-core/src/Converter.js
@@ -195,6 +195,7 @@ class Converter {
 <style>
 * { margin: 0; padding: 0; }
 html { background-color: ${provider.getBackgroundColor(options)}; }
+svg { vertical-align: top; }
 </style>`;
     if (start >= 0) {
       html += input.substring(start);


### PR DESCRIPTION
Example image
```svg
<?xml version="1.0" encoding="UTF-8" ?>
<svg height="5" width="5" xmlns="http://www.w3.org/2000/svg">
    <rect fill="#0000FF" height="5" width="5" x="0" y="0"/>
</svg>
```

If a `svg` image has a small height, `Puppeteer` / `Chromium` will render it with a top margin and the screenshot for the `png` image at `0:0` position will end in a transparent image or partially cut image
![wrong](https://user-images.githubusercontent.com/16632028/89333880-ed6c7280-d695-11ea-8fde-011b367ecc1b.png)

This is because `svg` is an `inline` element and `vertical-align` is `baseline` and `font-size` is `16px` by default

This PR fix it by style the `svg` element `vertical-align: top`
![correct](https://user-images.githubusercontent.com/16632028/89333904-fa896180-d695-11ea-85eb-abea94dcf2e8.png)

More infos at https://stackoverflow.com/questions/22337292/spurious-margin-on-svg-element#answer-22337325

The tests are already broken before in your `master` / `develop` branch

May https://github.com/neocotic/convert-svg/issues/59 is also fixed with this PR